### PR TITLE
Allow selective configuration of which compression libraries to use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,20 @@ license = "MIT"
 [dependencies]
 ar = "0.9"
 arrayvec = "0.7"
-bzip2 = "0.4"
-flate2 = "1.0"
+bzip2 = { version = "0.4", optional = true }
+flate2 = { version = "1.0", optional = true }
 infer = "0.8"
 log = "0.4"
 indexmap = "1.6"
 tar = "0.4"
-xz2 = "0.1"
-zstd = "0.11"
+xz2 = { version = "0.1", optional = true }
+zstd = { version = "0.11", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
 tempfile = "3.2"
+
+[features]
+default = ["bzip2", "gzip", "xz", "zstd"]
+gzip = ["flate2"]
+xz = ["xz2"]

--- a/src/control.rs
+++ b/src/control.rs
@@ -364,16 +364,14 @@ mod tests {
     #[test]
     fn control_keys_list_everything() {
         let ctrl = Control::parse(&b"package: name\nversion: 1.8.2\nTest: a"[..]).unwrap();
-        let tags: std::vec::Vec<&str> = ctrl.tags().collect();
-        assert!(tags.len() == 3);
+        assert!(ctrl.tags().count() == 3);
     }
 
     #[test]
     fn control_keys_captures_dash() {
         let ctrl =
             Control::parse(&b"package: name\nversion: 1.8.2\nInstalled-Size: a"[..]).unwrap();
-        let tags: std::vec::Vec<&str> = ctrl.tags().collect();
-        assert!(tags.len() == 3);
+        assert!(ctrl.tags().count() == 3);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,10 @@ pub enum Error {
     /// The entry in the deb package was an unknown file format
     UnknownEntryFormat,
 
+    /// The entry in the deb package was for a file format that
+    /// was not configured in features
+    UnconfiguredFileFormat(String),
+
     /// These was an IoError during the parsing
     Io(IoError),
 }
@@ -59,6 +63,9 @@ impl fmt::Display for Error {
             Error::DataAlreadyRead => write!(f, "data archive has been past"),
             Error::UnknownEntryFormat => {
                 write!(f, "entry in debian package has unknown file format")
+            }
+            Error::UnconfiguredFileFormat(ref format) => {
+                write!(f, "entry in debian package requires feature {}", format)
             }
             Error::Io(ref err) => write!(f, "{}", err),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,17 +212,45 @@ fn get_tar_from_entry<'a, R: 'a + Read>(
         let entry: Box<dyn Read> = Box::new(entry);
         Ok(tar::Archive::new(entry))
     } else if is_gz {
-        let gz: Box<dyn Read> = Box::new(flate2::read::GzDecoder::new(entry));
-        Ok(tar::Archive::new(gz))
+        #[cfg(feature = "gzip")]
+        {
+            let gz: Box<dyn Read> = Box::new(flate2::read::GzDecoder::new(entry));
+            Ok(tar::Archive::new(gz))
+        }
+        #[cfg(not(feature = "gzip"))]
+        {
+            Err(Error::UnconfiguredFileFormat("gzip".to_string()))
+        }
     } else if is_xz {
-        let xz: Box<dyn Read> = Box::new(xz2::read::XzDecoder::new_multi_decoder(entry));
-        Ok(tar::Archive::new(xz))
+        #[cfg(feature = "xz")]
+        {
+            let xz: Box<dyn Read> = Box::new(xz2::read::XzDecoder::new_multi_decoder(entry));
+            Ok(tar::Archive::new(xz))
+        }
+        #[cfg(not(feature = "xz"))]
+        {
+            Err(Error::UnconfiguredFileFormat("xz".to_string()))
+        }
     } else if is_bz2 {
-        let bz2: Box<dyn Read> = Box::new(bzip2::read::BzDecoder::new(entry));
-        Ok(tar::Archive::new(bz2))
+        #[cfg(feature = "bzip2")]
+        {
+            let bz2: Box<dyn Read> = Box::new(bzip2::read::BzDecoder::new(entry));
+            Ok(tar::Archive::new(bz2))
+        }
+        #[cfg(not(feature = "bzip2"))]
+        {
+            Err(Error::UnconfiguredFileFormat("bzip2".to_string()))
+        }
     } else if is_zst {
-        let zstd: Box<dyn Read> = Box::new(zstd::stream::read::Decoder::new(entry)?);
-        Ok(tar::Archive::new(zstd))
+        #[cfg(feature = "zstd")]
+        {
+            let zstd: Box<dyn Read> = Box::new(zstd::stream::read::Decoder::new(entry)?);
+            Ok(tar::Archive::new(zstd))
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            Err(Error::UnconfiguredFileFormat("zstd".to_string()))
+        }
     } else {
         Err(Error::UnknownEntryFormat)
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,3 @@
-use debpkg;
 use tempfile::NamedTempFile;
 
 use std::convert::TryFrom;


### PR DESCRIPTION
Use features to select which compression libraries debpkg supports. By default, support everything.

---

Wanted to propose this - being able to turn off packages like zstd might be useful for people.